### PR TITLE
feat: add output quote methods to uniswap

### DIFF
--- a/contracts/UniV3Quoter/interfaces/IUniswapV3StaticQuoter.sol
+++ b/contracts/UniV3Quoter/interfaces/IUniswapV3StaticQuoter.sol
@@ -32,4 +32,12 @@ interface IUniswapV3StaticQuoter {
         external
         view
         returns (uint256 amountOut);
+
+    struct QuoteExactOutputSingleParams {
+		address tokenIn;
+		address tokenOut;
+		uint256 amountOut;
+		uint24 fee;
+		uint160 sqrtPriceLimitX96;
+	}
 }


### PR DESCRIPTION
This pull request intends to add the following methods as static-view to the `UniswapV3StaticQuoter.sol` contract.

```js
        /// @notice Returns the amount in required for a given exact output swap without executing the swap
	/// @param path The path of the swap, i.e. each token pair and the pool fee
	/// @param amountOut The amount of the last token to receive
	/// @return amountIn The amount of first token required to be paid
	function quoteExactOutput(bytes memory path, uint256 amountOut) external view returns (uint256 amountIn);

	/// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
	/// @param tokenIn The token being swapped in
	/// @param tokenOut The token being swapped out
	/// @param fee The fee of the token pool to consider for the pair
	/// @param amountOut The desired output amount
	/// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
	/// @return amountIn The amount required as the input for the swap in order to receive `amountOut`
	function quoteExactOutputSingle(
		address tokenIn,
		address tokenOut,
		uint24 fee,
		uint256 amountOut,
		uint160 sqrtPriceLimitX96
	) external view returns (uint256 amountIn);
```